### PR TITLE
Flatten UI document style

### DIFF
--- a/gif_app/templates/index.html
+++ b/gif_app/templates/index.html
@@ -5,8 +5,8 @@
     <title>GIF Generator</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
-<body class="bg-gray-100 min-h-screen flex items-start font-sans">
-    <div class="bg-white p-6 rounded shadow-md w-full max-w-md text-left mx-4">
+<body class="bg-gray-200 min-h-screen py-10 flex justify-center font-serif">
+    <div class="bg-white p-10 border border-gray-300 w-full max-w-prose text-left mx-4">
         <h1 class="text-2xl font-bold mb-4">GIF Generator</h1>
         <form id="gifForm" action="/generate" method="post" enctype="multipart/form-data" class="space-y-4">
             <div>
@@ -16,12 +16,12 @@
             </div>
             <div>
                 <h2 class="font-bold mb-1">&#9313; Generate GIF</h2>
-                <button class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" type="submit">Generate GIF</button>
+                <button class="px-4 py-2 bg-blue-500 text-white hover:bg-blue-600" type="submit">Generate GIF</button>
                 <img id="gifPreview" class="mt-4 hidden" alt="Generated GIF">
             </div>
             <div>
                 <h2 class="font-bold mb-1">&#9314; Download GIF</h2>
-                <a id="downloadBtn" class="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 inline-block mt-2 hidden" download="output.gif">Download GIF</a>
+                <a id="downloadBtn" class="px-4 py-2 bg-green-500 text-white hover:bg-green-600 inline-block mt-2 hidden" download="output.gif">Download GIF</a>
             </div>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- switch to a light serif document-style layout
- drop 3D effects from container and buttons

## Testing
- `python -m py_compile gif_app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6854ac50317883338af04c64c466826a