### PR TITLE
Make GIF always 800x800

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # random
 
 This repository contains experiments. Included is a small Flask application
-that can generate a GIF from uploaded images.
+that can generate a GIF from uploaded images. The resulting animation is
+always 800&times;800 pixels, with each frame resized to fit without
+distortion.
 
 The HTML template now uses [Tailwind CSS](https://tailwindcss.com/) via CDN to
 provide basic styling.


### PR DESCRIPTION
## Summary
- ensure GIF frames are resized to a 800x800 canvas
- mention new fixed GIF dimensions in README

## Testing
- `python -m py_compile gif_app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6854b7bb22888333b3e978a531def40b