### PR TITLE
Remove button margins

### DIFF
--- a/gif_app/templates/index.html
+++ b/gif_app/templates/index.html
@@ -13,7 +13,7 @@
                 <h2 class="font-bold mb-1">&#9312; Upload Images</h2>
                 <p class="mb-2">add a bunch of images from your computer.</p>
                 <input id="imageInput" class="hidden" type="file" name="images" multiple accept="image/*">
-                <label for="imageInput" id="fileLabel" class="p-2 m-2 bg-black text-white hover:bg-gray-800 inline-flex cursor-pointer rounded-lg items-center space-x-2">
+                <label for="imageInput" id="fileLabel" class="p-2 bg-black text-white hover:bg-gray-800 inline-flex cursor-pointer rounded-lg items-center space-x-2">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-4 w-4">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v6m-3-3h6M12 3a9 9 0 100 18 9 9 0 000-18z" />
                     </svg>
@@ -24,7 +24,7 @@
             <div>
                 <h2 class="font-bold mb-1">&#9313; Generate GIF</h2>
                 <p class="mb-2">Press this button to create a GIF, it's that simple.</p>
-                <button id="generateBtn" class="p-2 m-2 bg-black text-white hover:bg-gray-800 opacity-50 pointer-events-none rounded-lg inline-flex items-center space-x-2" type="submit" disabled>
+                <button id="generateBtn" class="p-2 bg-black text-white hover:bg-gray-800 opacity-50 pointer-events-none rounded-lg inline-flex items-center space-x-2" type="submit" disabled>
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-4 w-4">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 10.5h-3v3h3m3-3v6m3-6h3m0 0v6m-3-3h2.25" />
                     </svg>
@@ -35,7 +35,7 @@
             <div>
                 <h2 class="font-bold mb-1">&#9314; Download GIF</h2>
                 <p class="mb-2">And now you can download it on your computer, or copy and past in your slides. Can you believe it?</p>
-                <a id="downloadBtn" class="p-2 m-2 bg-black text-white hover:bg-gray-800 inline-flex opacity-50 pointer-events-none rounded-lg items-center space-x-2" download="output.gif">
+                <a id="downloadBtn" class="p-2 bg-black text-white hover:bg-gray-800 inline-flex opacity-50 pointer-events-none rounded-lg items-center space-x-2" download="output.gif">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="h-4 w-4">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-4.5-6L12 3m0 0L7.5 10.5M12 3v13.5" />
                     </svg>


### PR DESCRIPTION
## Summary
- remove default Tailwind margin around action buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68559c2e97b88333ae30b1b062b76fe7