### PR TITLE
Remove copy feature

### DIFF
--- a/gif_app/templates/index.html
+++ b/gif_app/templates/index.html
@@ -48,15 +48,11 @@
             </div>
             <div>
                 <h2 class="font-bold mb-1">&#9315; Bring it home</h2>
-                <p class="mb-2 text-gray-700">And now you can download it on your computer, or copy and past in your slides. Can you believe it?</p>
+                <p class="mb-2 text-gray-700">And now you can download it on your computer. Can you believe it?</p>
                 <a id="downloadBtn" class="p-2 bg-black text-white hover:bg-gray-800 inline-flex opacity-50 pointer-events-none rounded-lg items-center space-x-2" download="output.gif">
                     <i data-lucide="download" class="h-4 w-4"></i>
                     <span>download</span>
                 </a>
-                <button id="copyBtn" type="button" class="p-2 bg-black text-white hover:bg-gray-800 inline-flex opacity-50 pointer-events-none rounded-lg items-center space-x-2 ml-2">
-                    <i data-lucide="copy" class="h-4 w-4"></i>
-                    <span>copy</span>
-                </button>
             </div>
         </form>
     </div>
@@ -66,7 +62,6 @@
         const gifForm = document.getElementById('gifForm');
         const gifPreview = document.getElementById('gifPreview');
         const downloadBtn = document.getElementById('downloadBtn');
-        const copyBtn = document.getElementById('copyBtn');
         let currentBlob = null;
         const generateBtn = document.getElementById('generateBtn');
         const clearBtn = document.getElementById('clearBtn');
@@ -153,17 +148,10 @@
             gifPreview.classList.add('hidden');
             downloadBtn.removeAttribute('href');
             downloadBtn.classList.add('opacity-50', 'pointer-events-none');
-            copyBtn.classList.add('opacity-50', 'pointer-events-none');
             currentBlob = null;
             updateClearBtnState();
         });
 
-        copyBtn.addEventListener('click', () => {
-            if (!currentBlob || !navigator.clipboard || !window.ClipboardItem) return;
-            navigator.clipboard.write([
-                new ClipboardItem({ 'image/gif': currentBlob })
-            ]);
-        });
 
         function generateGif() {
             if (isGenerating || files.length === 0) return;
@@ -180,7 +168,6 @@
                     gifPreview.classList.remove('hidden');
                     downloadBtn.href = url;
                     downloadBtn.classList.remove('opacity-50', 'pointer-events-none');
-                    copyBtn.classList.remove('opacity-50', 'pointer-events-none');
                     updateClearBtnState();
                 })
                 .finally(() => {


### PR DESCRIPTION
## Summary
- remove copy button from the GIF generator
- drop associated clipboard functionality

## Testing
- `python -m py_compile gif_app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6855d318107c833386ec41de4b81a4be