### PR TITLE
Add customizable GIF size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # random
 
 This repository contains experiments. Included is a small Flask application
-that can generate a GIF from uploaded images. The resulting animation is
-always 800&times;800 pixels, with each frame resized to fit without
-distortion.
+that can generate a GIF from uploaded images. The resulting animation by
+default is 800&times;800 pixels, but you can now customize the dimensions in
+the web interface. Each frame is resized to fit without distortion and the
+color depth is automatically adjusted based on the chosen size.
 
 The HTML template now uses [Tailwind CSS](https://tailwindcss.com/) via CDN to
 provide basic styling and includes icons from

--- a/gif_app/app.py
+++ b/gif_app/app.py
@@ -2,7 +2,7 @@ from io import BytesIO
 from flask import Flask, render_template, request, send_file
 from PIL import Image
 
-TARGET_SIZE = (800, 800)
+DEFAULT_SIZE = (800, 800)
 
 app = Flask(__name__)
 
@@ -14,26 +14,39 @@ def index():
 def generate():
     files = request.files.getlist('images')
     duration = int(request.form.get('duration', 300))
+    width = int(request.form.get('width', DEFAULT_SIZE[0]))
+    height = int(request.form.get('height', DEFAULT_SIZE[1]))
+    target_size = (width, height)
     frames = []
     for f in files:
         if f.filename:
             img = Image.open(f.stream).convert('RGBA')
-            img.thumbnail(TARGET_SIZE, Image.LANCZOS)
-            frame = Image.new('RGBA', TARGET_SIZE, (255, 255, 255, 0))
-            frame.paste(img, ((TARGET_SIZE[0] - img.width) // 2,
-                              (TARGET_SIZE[1] - img.height) // 2))
+            img.thumbnail(target_size, Image.LANCZOS)
+            frame = Image.new('RGBA', target_size, (255, 255, 255, 0))
+            frame.paste(img, ((target_size[0] - img.width) // 2,
+                              (target_size[1] - img.height) // 2))
             frames.append(frame)
     if not frames:
         return 'No images uploaded', 400
+    # determine color depth based on target size to keep reasonable file size
+    reference_pixels = DEFAULT_SIZE[0] * DEFAULT_SIZE[1]
+    target_pixels = width * height
+    color_ratio = reference_pixels / target_pixels if target_pixels else 1
+    colors = max(16, min(256, int(256 * color_ratio)))
+
+    processed_frames = [f.convert('P', palette=Image.ADAPTIVE, colors=colors)
+                        for f in frames]
+
     gif_bytes = BytesIO()
-    frames[0].save(
+    processed_frames[0].save(
         gif_bytes,
         format='GIF',
         save_all=True,
-        append_images=frames[1:],
+        append_images=processed_frames[1:],
         duration=duration,
         loop=0,
-        disposal=2
+        disposal=2,
+        optimize=True
     )
     gif_bytes.seek(0)
     return send_file(

--- a/gif_app/templates/index.html
+++ b/gif_app/templates/index.html
@@ -32,6 +32,14 @@
                     <div id="durationLabel" class="mb-1">Duration: <span id="durationValue">300</span> ms</div>
                     <input id="durationInput" type="range" min="50" max="1000" step="50" value="300" class="w-40">
                 </div>
+                <div class="mt-4">
+                    <div id="sizeLabel" class="mb-1">Size: <span id="widthValue">800</span> x <span id="heightValue">800</span> px</div>
+                    <div class="flex space-x-2">
+                        <input id="widthInput" type="number" min="100" max="2000" value="800" class="w-20 p-1 border rounded" />
+                        <span class="self-center">x</span>
+                        <input id="heightInput" type="number" min="100" max="2000" value="800" class="w-20 p-1 border rounded" />
+                    </div>
+                </div>
             </div>
             <div>
                 <h2 class="font-bold mb-1">&#9314; Generate</h2>
@@ -67,11 +75,16 @@
         const clearBtn = document.getElementById('clearBtn');
         const durationInput = document.getElementById('durationInput');
         const durationValue = document.getElementById('durationValue');
+        const widthInput = document.getElementById('widthInput');
+        const heightInput = document.getElementById('heightInput');
+        const widthValue = document.getElementById('widthValue');
+        const heightValue = document.getElementById('heightValue');
         let files = [];
         let isGenerating = false;
         updateGenerateBtnState();
         updateClearBtnState();
         updateDurationDisplay();
+        updateSizeDisplay();
 
         durationInput.addEventListener('input', () => {
             updateDurationDisplay();
@@ -80,8 +93,27 @@
             }
         });
 
+        widthInput.addEventListener('input', () => {
+            updateSizeDisplay();
+            if (gifPreview.src) {
+                generateGif();
+            }
+        });
+
+        heightInput.addEventListener('input', () => {
+            updateSizeDisplay();
+            if (gifPreview.src) {
+                generateGif();
+            }
+        });
+
         function updateDurationDisplay() {
             durationValue.textContent = durationInput.value;
+        }
+
+        function updateSizeDisplay() {
+            widthValue.textContent = widthInput.value;
+            heightValue.textContent = heightInput.value;
         }
 
         function updateGenerateBtnState() {
@@ -159,6 +191,8 @@
             const formData = new FormData();
             files.forEach(f => formData.append('images', f));
             formData.append('duration', durationInput.value);
+            formData.append('width', widthInput.value);
+            formData.append('height', heightInput.value);
             fetch('/generate', { method: 'POST', body: formData })
                 .then(res => res.blob())
                 .then(blob => {


### PR DESCRIPTION
## Summary
- allow customizing GIF output dimensions in the UI
- send width and height values to the backend
- compute frames based on requested size and adjust color depth for large GIFs
- optimize GIF saving
- update README to mention size customization

## Testing
- `python -m py_compile gif_app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6855e501dbe883338874b27a964640ec