### PR TITLE
Add slider for GIF size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This repository contains experiments. Included is a small Flask application
 that can generate a GIF from uploaded images. The resulting animation is
-always 800&times;800 pixels, with each frame resized to fit without
-distortion.
+always 800&times;800 pixels by default, with each frame resized to fit without
+distortion. A slider allows you to pick the maximum file size in megabytes;
+the server will try to scale the frames to keep the GIF under that limit.
 
 The HTML template now uses [Tailwind CSS](https://tailwindcss.com/) via CDN to
 provide basic styling and includes icons from

--- a/gif_app/app.py
+++ b/gif_app/app.py
@@ -3,6 +3,7 @@ from flask import Flask, render_template, request, send_file
 from PIL import Image
 
 TARGET_SIZE = (800, 800)
+DEFAULT_MAX_MB = 4
 
 app = Flask(__name__)
 
@@ -14,27 +15,47 @@ def index():
 def generate():
     files = request.files.getlist('images')
     duration = int(request.form.get('duration', 300))
-    frames = []
+    max_mb = int(request.form.get('max_size', DEFAULT_MAX_MB))
+    max_bytes = max_mb * 1024 * 1024
+
+    images = []
     for f in files:
         if f.filename:
             img = Image.open(f.stream).convert('RGBA')
             img.thumbnail(TARGET_SIZE, Image.LANCZOS)
-            frame = Image.new('RGBA', TARGET_SIZE, (255, 255, 255, 0))
-            frame.paste(img, ((TARGET_SIZE[0] - img.width) // 2,
-                              (TARGET_SIZE[1] - img.height) // 2))
-            frames.append(frame)
-    if not frames:
+            images.append(img)
+
+    if not images:
         return 'No images uploaded', 400
+
+    scale = 1.0
     gif_bytes = BytesIO()
-    frames[0].save(
-        gif_bytes,
-        format='GIF',
-        save_all=True,
-        append_images=frames[1:],
-        duration=duration,
-        loop=0,
-        disposal=2
-    )
+    for _ in range(5):
+        size = (int(TARGET_SIZE[0] * scale), int(TARGET_SIZE[1] * scale))
+        frames = []
+        for img in images:
+            frame = Image.new('RGBA', size, (255, 255, 255, 0))
+            temp = img.copy()
+            temp.thumbnail(size, Image.LANCZOS)
+            frame.paste(temp, ((size[0] - temp.width) // 2,
+                              (size[1] - temp.height) // 2))
+            frames.append(frame)
+        gif_bytes.seek(0)
+        gif_bytes.truncate()
+        frames[0].save(
+            gif_bytes,
+            format='GIF',
+            save_all=True,
+            append_images=frames[1:],
+            duration=duration,
+            loop=0,
+            disposal=2,
+            optimize=True
+        )
+        if len(gif_bytes.getvalue()) <= max_bytes:
+            break
+        scale *= 0.9
+
     gif_bytes.seek(0)
     return send_file(
         gif_bytes,

--- a/gif_app/templates/index.html
+++ b/gif_app/templates/index.html
@@ -32,6 +32,10 @@
                     <div id="durationLabel" class="mb-1">Duration: <span id="durationValue">300</span> ms</div>
                     <input id="durationInput" type="range" min="50" max="1000" step="50" value="300" class="w-40">
                 </div>
+                <div class="mt-1">
+                    <div id="sizeLabel" class="mb-1">Max size: <span id="sizeValue">4</span> MB</div>
+                    <input id="sizeInput" type="range" min="1" max="10" step="1" value="4" class="w-40">
+                </div>
             </div>
             <div>
                 <h2 class="font-bold mb-1">&#9314; Generate</h2>
@@ -67,11 +71,14 @@
         const clearBtn = document.getElementById('clearBtn');
         const durationInput = document.getElementById('durationInput');
         const durationValue = document.getElementById('durationValue');
+        const sizeInput = document.getElementById('sizeInput');
+        const sizeValue = document.getElementById('sizeValue');
         let files = [];
         let isGenerating = false;
         updateGenerateBtnState();
         updateClearBtnState();
         updateDurationDisplay();
+        updateSizeDisplay();
 
         durationInput.addEventListener('input', () => {
             updateDurationDisplay();
@@ -79,9 +86,19 @@
                 generateGif();
             }
         });
+        sizeInput.addEventListener('input', () => {
+            updateSizeDisplay();
+            if (gifPreview.src) {
+                generateGif();
+            }
+        });
 
         function updateDurationDisplay() {
             durationValue.textContent = durationInput.value;
+        }
+
+        function updateSizeDisplay() {
+            sizeValue.textContent = sizeInput.value;
         }
 
         function updateGenerateBtnState() {
@@ -159,6 +176,7 @@
             const formData = new FormData();
             files.forEach(f => formData.append('images', f));
             formData.append('duration', durationInput.value);
+            formData.append('max_size', sizeInput.value);
             fetch('/generate', { method: 'POST', body: formData })
                 .then(res => res.blob())
                 .then(blob => {


### PR DESCRIPTION
## Summary
- control the maximum GIF file size with a new slider
- scale frames on the server so the output stays below the selected limit
- mention the feature in the README

## Testing
- `python -m py_compile gif_app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6856003fb8188333a574b4047511ca5f