### PR TITLE
Add GIF dimension slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # random
 
 This repository contains experiments. Included is a small Flask application
-that can generate a GIF from uploaded images. The resulting animation is
-always 800&times;800 pixels by default, with each frame resized to fit without
-distortion. A slider allows you to pick the maximum file size in megabytes;
-the server will try to scale the frames to keep the GIF under that limit.
+that can generate a GIF from uploaded images. You can choose the dimension of
+the square output via a slider; it defaults to 800&times;800 pixels. A second
+slider lets you pick the maximum file size in megabytes, and the server will
+try to scale the frames to keep the GIF under that limit.
 
 The HTML template now uses [Tailwind CSS](https://tailwindcss.com/) via CDN to
 provide basic styling and includes icons from

--- a/gif_app/app.py
+++ b/gif_app/app.py
@@ -2,7 +2,7 @@ from io import BytesIO
 from flask import Flask, render_template, request, send_file
 from PIL import Image
 
-TARGET_SIZE = (800, 800)
+DEFAULT_DIMENSION = 800
 DEFAULT_MAX_MB = 4
 
 app = Flask(__name__)
@@ -15,14 +15,16 @@ def index():
 def generate():
     files = request.files.getlist('images')
     duration = int(request.form.get('duration', 300))
+    dimension = int(request.form.get('dimension', DEFAULT_DIMENSION))
     max_mb = int(request.form.get('max_size', DEFAULT_MAX_MB))
     max_bytes = max_mb * 1024 * 1024
+    target_size = (dimension, dimension)
 
     images = []
     for f in files:
         if f.filename:
             img = Image.open(f.stream).convert('RGBA')
-            img.thumbnail(TARGET_SIZE, Image.LANCZOS)
+            img.thumbnail(target_size, Image.LANCZOS)
             images.append(img)
 
     if not images:
@@ -31,7 +33,7 @@ def generate():
     scale = 1.0
     gif_bytes = BytesIO()
     for _ in range(5):
-        size = (int(TARGET_SIZE[0] * scale), int(TARGET_SIZE[1] * scale))
+        size = (int(target_size[0] * scale), int(target_size[1] * scale))
         frames = []
         for img in images:
             frame = Image.new('RGBA', size, (255, 255, 255, 0))

--- a/gif_app/templates/index.html
+++ b/gif_app/templates/index.html
@@ -33,6 +33,10 @@
                     <input id="durationInput" type="range" min="50" max="1000" step="50" value="300" class="w-40">
                 </div>
                 <div class="mt-1">
+                    <div id="dimensionLabel" class="mb-1">Dimension: <span id="dimensionValue">800</span> px</div>
+                    <input id="dimensionInput" type="range" min="200" max="1000" step="50" value="800" class="w-40">
+                </div>
+                <div class="mt-1">
                     <div id="sizeLabel" class="mb-1">Max size: <span id="sizeValue">4</span> MB</div>
                     <input id="sizeInput" type="range" min="1" max="10" step="1" value="4" class="w-40">
                 </div>
@@ -71,6 +75,8 @@
         const clearBtn = document.getElementById('clearBtn');
         const durationInput = document.getElementById('durationInput');
         const durationValue = document.getElementById('durationValue');
+        const dimensionInput = document.getElementById('dimensionInput');
+        const dimensionValue = document.getElementById('dimensionValue');
         const sizeInput = document.getElementById('sizeInput');
         const sizeValue = document.getElementById('sizeValue');
         let files = [];
@@ -78,10 +84,17 @@
         updateGenerateBtnState();
         updateClearBtnState();
         updateDurationDisplay();
+        updateDimensionDisplay();
         updateSizeDisplay();
 
         durationInput.addEventListener('input', () => {
             updateDurationDisplay();
+            if (gifPreview.src) {
+                generateGif();
+            }
+        });
+        dimensionInput.addEventListener('input', () => {
+            updateDimensionDisplay();
             if (gifPreview.src) {
                 generateGif();
             }
@@ -95,6 +108,10 @@
 
         function updateDurationDisplay() {
             durationValue.textContent = durationInput.value;
+        }
+
+        function updateDimensionDisplay() {
+            dimensionValue.textContent = dimensionInput.value;
         }
 
         function updateSizeDisplay() {
@@ -176,6 +193,7 @@
             const formData = new FormData();
             files.forEach(f => formData.append('images', f));
             formData.append('duration', durationInput.value);
+            formData.append('dimension', dimensionInput.value);
             formData.append('max_size', sizeInput.value);
             fetch('/generate', { method: 'POST', body: formData })
                 .then(res => res.blob())


### PR DESCRIPTION
## Summary
- allow user to pick GIF dimension via new slider
- wire up new dimension parameter in JS and server
- document the new slider in README

## Testing
- `python -m py_compile gif_app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685602d732fc8333b8036804f891df9c