### PR TITLE
Add macOS packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,18 @@ The title font comes from [Google Fonts](https://fonts.google.com/) and uses the
 
 3. Open your browser at [http://localhost:5000](http://localhost:5000)
 and upload images to receive the generated GIF.
+
+## Packaging for macOS
+
+To create a standalone macOS application you can use [PyInstaller](https://www.pyinstaller.org/).
+
+1. Install PyInstaller:
+   ```bash
+   pip install pyinstaller
+   ```
+2. Run the provided script:
+   ```bash
+   ./build_macos.sh
+   ```
+
+The resulting `.app` bundle will be placed in the `dist/` directory. Run these steps on a Mac machine with Python installed.

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+pyinstaller --onefile --windowed \
+  --name Giffer \
+  --add-data "gif_app/templates:gif_app/templates" \
+  gif_app/app.py


### PR DESCRIPTION
## Summary
- add `build_macos.sh` for bundling the Flask app using PyInstaller
- document macOS packaging steps in the README

## Testing
- `python -m py_compile gif_app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6860d0d20424833380205531e05b1a95