### PR TITLE
Fix template path for gif_app

### DIFF
--- a/gif_app/app.py
+++ b/gif_app/app.py
@@ -1,11 +1,13 @@
 from io import BytesIO
+from pathlib import Path
 from flask import Flask, render_template, request, send_file
 from PIL import Image
 
 DEFAULT_DIMENSION = 800
 DEFAULT_MAX_MB = 4
 
-app = Flask(__name__)
+APP_ROOT = Path(__file__).resolve().parent
+app = Flask(__name__, template_folder=str(APP_ROOT / "templates"))
 
 @app.route('/', methods=['GET'])
 def index():


### PR DESCRIPTION
## Summary
- set template folder relative to `gif_app/app.py`

## Testing
- `python -m py_compile gif_app/app.py`
- `bash build_macos.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6860d93ee1b08333a9486c15a73e243d