### PR TITLE
Keep uploaded images after GIF generation

### DIFF
--- a/gif_app/app.py
+++ b/gif_app/app.py
@@ -60,7 +60,7 @@ def clear():
 @app.route('/generate', methods=['POST'])
 def generate():
     sid = get_sid()
-    images = UPLOAD_STORE.pop(sid, [])
+    images = UPLOAD_STORE.get(sid, [])
     duration = int(request.form.get('duration', 300))
     dimension = int(request.form.get('dimension', DEFAULT_DIMENSION))
     max_mb = int(request.form.get('max_size', DEFAULT_MAX_MB))

--- a/gif_app/templates/index.html
+++ b/gif_app/templates/index.html
@@ -247,7 +247,6 @@
                     gifPreview.classList.remove('hidden');
                     downloadBtn.href = url;
                     downloadBtn.classList.remove('opacity-50', 'pointer-events-none');
-                    files = [];
                     renderPreviews();
                     updateGenerateBtnState();
                     updateUploadCounter();


### PR DESCRIPTION
## Summary
- ensure uploaded images persist after generating a GIF

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a647a4c08333adf698ed5a2d3588