### PR TITLE
Fix stale GIFs on repeated generation

### DIFF
--- a/gif_app/templates/index.html
+++ b/gif_app/templates/index.html
@@ -199,6 +199,9 @@
         });
 
         clearBtn.addEventListener('click', () => {
+            if (gifPreview.src) {
+                URL.revokeObjectURL(gifPreview.src);
+            }
             gifPreview.src = '';
             gifPreview.classList.add('hidden');
             downloadBtn.removeAttribute('href');
@@ -221,6 +224,9 @@
                 .then(blob => {
                     currentBlob = blob;
                     const url = URL.createObjectURL(blob);
+                    if (gifPreview.src) {
+                        URL.revokeObjectURL(gifPreview.src);
+                    }
                     gifPreview.src = url;
                     gifPreview.classList.remove('hidden');
                     downloadBtn.href = url;


### PR DESCRIPTION
## Summary
- prevent object URL leaks when regenerating GIFs
- revoke the preview URL when clearing or overwriting the GIF

## Testing
- `python -m py_compile gif_app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6861c90e51a88333b0e58d40483c533e