### PR TITLE
Fix GIF regeneration

### DIFF
--- a/gif_app/templates/index.html
+++ b/gif_app/templates/index.html
@@ -246,6 +246,7 @@
             loadingIcon.classList.remove('hidden');
             lucide.createIcons();
             loadingIcon = document.getElementById('loadingIcon');
+            await fetch('/clear', { method: 'POST' });
             for (const f of files) {
                 const fd = new FormData();
                 fd.append('image', f);


### PR DESCRIPTION
## Summary
- clear frames on the server before re-uploading new ones

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6861d924d37c83338f9cf809619eb339