### PR TITLE
Add square mask option

### DIFF
--- a/gif_app/app.py
+++ b/gif_app/app.py
@@ -17,6 +17,7 @@ def generate():
     duration = int(request.form.get('duration', 300))
     dimension = int(request.form.get('dimension', DEFAULT_DIMENSION))
     max_mb = int(request.form.get('max_size', DEFAULT_MAX_MB))
+    square_mask = request.form.get('square_mask') == 'on'
     max_bytes = max_mb * 1024 * 1024
     target_size = (dimension, dimension)
 
@@ -24,6 +25,12 @@ def generate():
     for f in files:
         if f.filename:
             img = Image.open(f.stream).convert('RGBA')
+            if square_mask:
+                w, h = img.size
+                side = min(w, h)
+                left = (w - side) // 2
+                top = (h - side) // 2
+                img = img.crop((left, top, left + side, top + side))
             img.thumbnail(target_size, Image.LANCZOS)
             images.append(img)
 

--- a/gif_app/templates/index.html
+++ b/gif_app/templates/index.html
@@ -43,6 +43,10 @@
                     <div id="sizeLabel" class="mb-1">Max size: <span id="sizeValue">4</span> MB</div>
                     <input id="sizeInput" type="range" min="1" max="10" step="1" value="4" class="w-40">
                 </div>
+                <div class="mt-1 flex items-center space-x-2">
+                    <input id="maskInput" type="checkbox" class="h-4 w-4">
+                    <label for="maskInput">Square crop images</label>
+                </div>
             </div>
             <div>
                 <h2 class="font-bold mb-1">&#9314; Generate</h2>
@@ -82,6 +86,7 @@
         const dimensionValue = document.getElementById('dimensionValue');
         const sizeInput = document.getElementById('sizeInput');
         const sizeValue = document.getElementById('sizeValue');
+        const maskInput = document.getElementById('maskInput');
         let files = [];
         let isGenerating = false;
         updateGenerateBtnState();
@@ -104,6 +109,11 @@
         });
         sizeInput.addEventListener('input', () => {
             updateSizeDisplay();
+            if (gifPreview.src) {
+                generateGif();
+            }
+        });
+        maskInput.addEventListener('change', () => {
             if (gifPreview.src) {
                 generateGif();
             }
@@ -216,6 +226,7 @@
             formData.append('duration', durationInput.value);
             formData.append('dimension', dimensionInput.value);
             formData.append('max_size', sizeInput.value);
+            formData.append('square_mask', maskInput.checked ? 'on' : '');
             fetch('/generate', { method: 'POST', body: formData })
                 .then(res => res.blob())
                 .then(blob => {


### PR DESCRIPTION
## Summary
- allow users to optionally crop each frame to a square
- add checkbox to customize section
- include checkbox value in requests
- implement square cropping logic on the server

## Testing
- `python -m py_compile gif_app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6861e5ce0438833391ce9bd0748aa640