### PR TITLE
Add fill square option for GIF frames

### DIFF
--- a/gif_app/app.py
+++ b/gif_app/app.py
@@ -64,6 +64,7 @@ def generate():
     duration = int(request.form.get('duration', 300))
     dimension = int(request.form.get('dimension', DEFAULT_DIMENSION))
     max_mb = int(request.form.get('max_size', DEFAULT_MAX_MB))
+    cover = request.form.get('cover', '0') == '1'
     max_bytes = max_mb * 1024 * 1024
     target_size = (dimension, dimension)
 
@@ -78,9 +79,18 @@ def generate():
         for img in images:
             frame = Image.new('RGBA', size, (255, 255, 255, 0))
             temp = img.copy()
-            temp.thumbnail(size, Image.LANCZOS)
-            frame.paste(temp, ((size[0] - temp.width) // 2,
-                              (size[1] - temp.height) // 2))
+            if cover:
+                ratio = max(size[0] / temp.width, size[1] / temp.height)
+                new_size = (int(temp.width * ratio), int(temp.height * ratio))
+                temp = temp.resize(new_size, Image.LANCZOS)
+                left = (temp.width - size[0]) // 2
+                top = (temp.height - size[1]) // 2
+                temp = temp.crop((left, top, left + size[0], top + size[1]))
+                frame.paste(temp, (0, 0))
+            else:
+                temp.thumbnail(size, Image.LANCZOS)
+                frame.paste(temp, ((size[0] - temp.width) // 2,
+                                  (size[1] - temp.height) // 2))
             frames.append(frame)
         gif_bytes.seek(0)
         gif_bytes.truncate()

--- a/gif_app/templates/index.html
+++ b/gif_app/templates/index.html
@@ -52,10 +52,16 @@
                         <input id="sizeInput" type="range" min="1" max="10" step="1" value="4" class="w-40">
                     </div>
                 </div>
-                <div id="gifPlaceholder" class="mt-2 flex items-center justify-center bg-gray-200" style="width: 600px; height: 600px;">
-                    <i id="loadingIcon" data-lucide="loader" class="animate-spin h-8 w-8 hidden"></i>
-                    <img id="gifPreview" class="hidden object-contain w-full h-full" alt="Generated GIF">
+                <div class="mt-2">
+                    <label for="coverInput" class="inline-flex items-center space-x-2">
+                        <input id="coverInput" type="checkbox">
+                        <span>Fill square</span>
+                    </label>
                 </div>
+                <div id="gifPlaceholder" class="mt-2 flex items-center justify-center bg-gray-200" style="width: 600px; height: 600px;">
+                        <i id="loadingIcon" data-lucide="loader" class="animate-spin h-8 w-8 hidden"></i>
+                        <img id="gifPreview" class="hidden object-contain w-full h-full" alt="Generated GIF">
+                    </div>
             </div>
             <div>
                 <h2 class="font-bold mb-1">&#9315; Bring it home</h2>
@@ -90,6 +96,7 @@
         const dimensionValue = document.getElementById('dimensionValue');
         const sizeInput = document.getElementById('sizeInput');
         const sizeValue = document.getElementById('sizeValue');
+        const coverInput = document.getElementById('coverInput');
         const uploadCounter = document.getElementById('uploadCounter');
         let files = [];
         let isGenerating = false;
@@ -114,6 +121,11 @@
         });
         sizeInput.addEventListener('input', () => {
             updateSizeDisplay();
+            if (gifPreview.src) {
+                generateGif();
+            }
+        });
+        coverInput.addEventListener('change', () => {
             if (gifPreview.src) {
                 generateGif();
             }
@@ -257,6 +269,7 @@
             formData.append('duration', durationInput.value);
             formData.append('dimension', dimensionInput.value);
             formData.append('max_size', sizeInput.value);
+            formData.append('cover', coverInput.checked ? '1' : '0');
             fetch('/generate', { method: 'POST', body: formData })
                 .then(res => res.blob())
                 .then(blob => {


### PR DESCRIPTION
## Summary
- add a `cover` checkbox in the UI to fill the square frame
- send the new option to the backend
- crop frames to cover the target square if the option is selected

## Testing
- `python -m py_compile gif_app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6861e74e87748333b5041f4581181083